### PR TITLE
多段Proxy環境でIPアドレス取得にHTTP_X_FORWARDED_FOR等を利用した際にエラーになる問題を修正。

### DIFF
--- a/modules/error404logger/e404logger.class.inc.php
+++ b/modules/error404logger/e404logger.class.inc.php
@@ -93,6 +93,7 @@ var $tbl_error_404_logger;
 		if( !empty($remoteIPIndexName) && isset($_SERVER[$remoteIPIndexName]) )
 		{
 			$ip = $_SERVER[$remoteIPIndexName];
+			$ip = preg_replace('/.*[, ]([^, ]+)\z/','$1',$ip); //For multi stairs proxy
 		}else{
 			$ip = $_SERVER["REMOTE_ADDR"];
 		}


### PR DESCRIPTION
複数のProxyを経てWebサーバに到着するとX-Forwarded-Forに複数にIPアドレスが入るため、最後に入ったIPアドレスを採用するようにしました。
この修正なしで、そのまま流すとIPアドレス形式として不完全で途中でエラーになります。
